### PR TITLE
Stop yarn files being formatted

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,3 @@
 dist/
 node_modules
-.yarn/*
-!.yarn/patches
-!.yarn/plugins
-!.yarn/releases
-!.yarn/sdks
-!.yarn/versions
+.yarn/


### PR DESCRIPTION
Updates `.pretterignore` to stop yarn files being formatted.