### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
     pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/nblackburn/website/security/code-scanning/2](https://github.com/nblackburn/website/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to the least privilege necessary. Since the workflow only checks out code, sets up Node, installs dependencies, and runs linting/formatting, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`. This can be set at the workflow level (top-level, applying to all jobs) or at the job level (inside the `tests` job). The best practice is to set it at the workflow level unless a job requires different permissions. Edit `.github/workflows/lint.yml` to add the following block after the `name:` line and before the `on:` block:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
