### PR TITLE
Workflow permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,6 @@
 name: Playwright
+permissions:
+  contents: read
 on:
     deployment_status:
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/nblackburn/website/security/code-scanning/1](https://github.com/nblackburn/website/security/code-scanning/1)

To fix the problem, we should explicitly define the `permissions` block for the workflow. The simplest and most secure way is to set this at the workflow root (top level), which will apply to all jobs unless overridden. For this workflow, since it only checks out code, installs dependencies, runs tests, and uploads artifacts, the minimal required permission is `contents: read`. Optionally, if future use of artifact uploads would require additional permission, this can be revisited, but for now, `contents: read` is sufficient.  
**Implementation:**  
- At the top level of `.github/workflows/playwright.yml`, insert:

```yaml
permissions:
  contents: read
```

This is placed after the `name:` and before `on:` for best convention.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
